### PR TITLE
Fix code scanning alert no. 18: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/Season-1/Level-5/code.py
+++ b/Season-1/Level-5/code.py
@@ -24,35 +24,41 @@ class Random_generator:
         salt = ''.join(str(random.randint(0, 9)) for _ in range(21)) + '.'
         return f'$2b${rounds}${salt}'.encode()
 
-class SHA256_hasher:
+class Argon2_hasher:
 
-    # produces the password hash by combining password + salt because hashing
-    def password_hash(self, password, salt):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
-        password_hash = bcrypt.hashpw(password, salt)
-        return password_hash.decode('ascii')
+    def __init__(self):
+        self.ph = PasswordHasher()
 
-    # verifies that the hashed password reverses to the plain text version on verification
-    def password_verification(self, password, password_hash):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
-        password_hash = password_hash.encode('ascii')
-        return bcrypt.checkpw(password, password_hash)
-
-class MD5_hasher:
-
-    # same as above but using a different algorithm to hash which is MD5
     def password_hash(self, password):
-        return hashlib.md5(password.encode()).hexdigest()
+        return self.ph.hash(password)
 
     def password_verification(self, password, password_hash):
-        password = self.password_hash(password)
-        return secrets.compare_digest(password.encode(), password_hash.encode())
+        try:
+            return self.ph.verify(password_hash, password)
+        except:
+            return False
+
+from argon2 import PasswordHasher
+
+class Argon2_hasher:
+
+    def __init__(self):
+        self.ph = PasswordHasher()
+
+    def password_hash(self, password):
+        return self.ph.hash(password)
+
+    def password_verification(self, password, password_hash):
+        try:
+            return self.ph.verify(password_hash, password)
+        except:
+            return False
 
 # a collection of sensitive secrets necessary for the software to operate
 PRIVATE_KEY = os.environ.get('PRIVATE_KEY')
 PUBLIC_KEY = os.environ.get('PUBLIC_KEY')
 SECRET_KEY = 'TjWnZr4u7x!A%D*G-KaPdSgVkXp2s5v8'
-PASSWORD_HASHER = 'MD5_hasher'
+PASSWORD_HASHER = 'Argon2_hasher'
 
 
 # Contribute new levels to the game in 3 simple steps!

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask
 flask-testing
 blinker
 requests
+argon2-cffi==23.1.0


### PR DESCRIPTION
Fixes [https://github.com/Ghcpuser1/skills-secure-code-game/security/code-scanning/18](https://github.com/Ghcpuser1/skills-secure-code-game/security/code-scanning/18)

To fix the problem, we need to replace the use of MD5 and SHA-256 for password hashing with a more secure and computationally expensive algorithm. Argon2 is a good choice for this purpose. We will use the `argon2-cffi` library to implement the password hashing and verification functions.

1. Replace the `MD5_hasher` class with a new `Argon2_hasher` class that uses Argon2 for password hashing and verification.
2. Update the `SHA256_hasher` class to use Argon2 instead of SHA-256.
3. Ensure that the new `Argon2_hasher` class is used in place of the `MD5_hasher` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
